### PR TITLE
Cleanup maintenance task

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,20 @@ if ($process->getStatus() == ProcessManagerBundle::STATUS_STOPPING) {
     $process->save();    
 }
 ```
+## Cleanup command
+
+You can execute a cleanup command from the console to delete old process entries and log files. To do this on a regular basis, you can add it as a cronjob. 
+
+```bash
+# delete all process lo entries from the database and log files older than 604800 seconds (7 days)
+$ ./bin/console process-manager:cleanup-process-data
+ 
+# delete all process lo entries from the database and log files older than 86400 seconds (1 days)
+$ ./bin/console process-manager:cleanup-process-data --seconds=86400
+
+# delete only process lo entries from the database older than 604800 seconds (7 days) and keep the log files
+$ ./bin/console process-manager:cleanup-process-data --logfiles=false
+```
 
 ## Copyright and license 
 Copyright: [lineofcode.at](http://www.lineofcode.at)

--- a/README.md
+++ b/README.md
@@ -130,14 +130,14 @@ if ($process->getStatus() == ProcessManagerBundle::STATUS_STOPPING) {
 You can execute a cleanup command from the console to delete old process entries and log files. To do this on a regular basis, you can add it as a cronjob. 
 
 ```bash
-# delete all process lo entries from the database and log files older than 604800 seconds (7 days)
+# delete all process entries from the database and log files older than 604800 seconds (7 days)
 $ ./bin/console process-manager:cleanup-process-data
  
-# delete all process lo entries from the database and log files older than 86400 seconds (1 days)
+# delete all process entries from the database and log files older than 86400 seconds (1 days)
 $ ./bin/console process-manager:cleanup-process-data --seconds=86400
 
-# delete only process lo entries from the database older than 604800 seconds (7 days) and keep the log files
-$ ./bin/console process-manager:cleanup-process-data --logfiles=false
+# delete only process entries from the database older than 604800 seconds (7 days) and keep the log files
+$ ./bin/console process-manager:cleanup-process-data --keeplogs
 ```
 
 ## Copyright and license 

--- a/src/ProcessManagerBundle/Command/CleanupProcessDataCommand.php
+++ b/src/ProcessManagerBundle/Command/CleanupProcessDataCommand.php
@@ -17,7 +17,6 @@ namespace ProcessManagerBundle\Command;
 
 use Doctrine\DBAL\Exception;
 use Pimcore\Console\AbstractCommand;
-use Pimcore\Db;
 use ProcessManagerBundle\Service\CleanupService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/ProcessManagerBundle/Command/CleanupProcessDataCommand.php
+++ b/src/ProcessManagerBundle/Command/CleanupProcessDataCommand.php
@@ -25,13 +25,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CleanupProcessDataCommand extends AbstractCommand
 {
-    private CleanupService $cleanupService;
-    private string $logDirectory;
-
-    public function __construct(CleanupService $cleanupService, string $logDirectory) {
+    public function __construct(private CleanupService $cleanupService, private string $logDirectory) {
         parent::__construct();
-        $this->cleanupService = $cleanupService;
-        $this->logDirectory = $logDirectory;
     }
 
     protected function configure(): void
@@ -75,14 +70,14 @@ EOT
         }
 
         // start deleting database entries older than x seconds
-        $this->output->writeln('start cleaning database entries older than ' . $seconds . ' seconds');
+        $output->writeln('start cleaning database entries older than ' . $seconds . ' seconds');
         $this->cleanupService->cleanupDbEntries($seconds);
-        $this->output->writeln('finish cleaning database entries older than ' . $seconds . ' seconds');
+        $output->writeln('finish cleaning database entries older than ' . $seconds . ' seconds');
 
         // start deleting log files older than x seconds
-        $this->output->writeln('start cleaning log files older than ' . $seconds . ' seconds');
+        $output->writeln('start cleaning log files older than ' . $seconds . ' seconds');
         $this->cleanupService->cleanupLogFiles($this->logDirectory, $seconds, $keepLogs);
-        $this->output->writeln('finish cleaning logfile entries older than ' . $seconds . ' seconds');
+        $output->writeln('finish cleaning logfile entries older than ' . $seconds . ' seconds');
         return Command::SUCCESS;
     }
 }

--- a/src/ProcessManagerBundle/Command/CleanupProcessDataCommand.php
+++ b/src/ProcessManagerBundle/Command/CleanupProcessDataCommand.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * Process Manager.
+ *
+ * LICENSE
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2020 Wojciech Peisert (http://divante.co/)
+ * @license    https://github.com/dpfaffenbauer/ProcessManager/blob/master/gpl-3.0.txt GNU General Public License version 3 (GPLv3)
+ */
+
+namespace ProcessManagerBundle\Command;
+
+use Doctrine\DBAL\Exception;
+use Pimcore\Console\AbstractCommand;
+use Pimcore\Db;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CleanupProcessDataCommand extends AbstractCommand
+{
+    private string $logDirectory;
+
+    public function __construct(string $logDirectory) {
+        parent::__construct();
+        $this->logDirectory = $logDirectory;
+    }
+    protected function configure(): void
+    {
+        $this
+            ->setName('process-manager:cleanup-process-data')
+            ->setDescription('Cleanup process data from the database and from log file directory')
+            ->setHelp(
+                <<<EOT
+The <info>%command.name%</info> cleanup process data from the database and from log file directory.
+EOT
+            )
+            ->addOption(
+                'logfiles',
+                'l',
+                InputOption::VALUE_OPTIONAL,
+                'Cleanup log files (default "true")',
+                true
+            )
+            ->addOption(
+                'seconds',
+                's',
+                InputOption::VALUE_OPTIONAL,
+                'Cleanup process data older than this number of seconds (default "604800" - 7 days)',
+                604800
+            );
+    }
+
+    /**
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return int
+     * @throws Exception
+     */
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if ($input->getOption('logfiles')) {
+            $included = (bool)$input->getOption('logfiles');
+        }
+        if ($input->getOption('seconds')) {
+            $seconds = (int)$input->getOption('seconds');
+        }
+
+        // start deleting database entries older than x seconds
+        $this->output->writeln('start cleaning database entries older than ' . $seconds . ' seconds');
+        $connection = Db::get();
+        $connection->executeStatement('DELETE FROM process_manager_processes  WHERE started < UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL ? SECOND))', [$seconds]);
+        $this->output->writeln('finish cleaning database entries older than ' . $seconds . ' seconds');
+
+        // start deleting log files older than x seconds
+        $this->output->writeln('start cleaning log files older than ' . $seconds . ' seconds');
+        if (is_dir($this->logDirectory)) {
+            $files = scandir($this->logDirectory);
+            foreach ($files as $file) {
+                if (
+                    file_exists($file) &&
+                    str_contains($file, 'process_manager_') &&
+                    filemtime($file) < time() - $seconds
+                ) {
+                    unlink($file);
+                }
+            }
+        }
+        $this->output->writeln('finish cleaning logfile entries older than ' . $seconds . ' seconds');
+        return Command::SUCCESS;
+    }
+}

--- a/src/ProcessManagerBundle/Controller/ProcessController.php
+++ b/src/ProcessManagerBundle/Controller/ProcessController.php
@@ -18,6 +18,7 @@ use CoreShop\Bundle\ResourceBundle\Controller\ResourceController;
 use Pimcore\Db;
 use ProcessManagerBundle\Model\Process;
 use ProcessManagerBundle\Model\ProcessInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -106,14 +107,14 @@ class ProcessController extends ResourceController
         );
     }
 
-    public function clearAction(Request $request): JsonResponse
+    public function clearAction(Request $request, ParameterBagInterface $parameterBag): JsonResponse
     {
         $seconds = (int)$request->get('seconds', 604_800);
         $connection = Db::get();
         $connection->executeStatement('DELETE FROM process_manager_processes  WHERE started < UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL ? SECOND))', [$seconds]);
 
-        $logDirectory = \Pimcore::getContainer()->getParameter('process_manager.log_directory');
-        $keepLogs = \Pimcore::getContainer()->getParameter('process_manager.keep_logs');
+        $logDirectory = $parameterBag->get('process_manager.log_directory');
+        $keepLogs = $parameterBag->get('process_manager.keep_logs');
         if (!$keepLogs && is_dir($logDirectory)) {
             $files = scandir($logDirectory);
             foreach ($files as $file) {

--- a/src/ProcessManagerBundle/Controller/ProcessController.php
+++ b/src/ProcessManagerBundle/Controller/ProcessController.php
@@ -113,16 +113,17 @@ class ProcessController extends ResourceController
         $connection->executeStatement('DELETE FROM process_manager_processes  WHERE started < UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL ? SECOND))', [$seconds]);
 
         $logDirectory = \Pimcore::getContainer()->getParameter('process_manager.log_directory');
-        $cleanupLogDirectory = \Pimcore::getContainer()->getParameter('process_manager.cleanup_log_directory');
-        if ($cleanupLogDirectory && is_dir($logDirectory)) {
+        $keepLogs = \Pimcore::getContainer()->getParameter('process_manager.keep_logs');
+        if (!$keepLogs && is_dir($logDirectory)) {
             $files = scandir($logDirectory);
             foreach ($files as $file) {
+                $filePath = $logDirectory . '/' . $file;
                 if (
-                    file_exists($file) &&
+                    file_exists($filePath) &&
                     str_contains($file, 'process_manager_') &&
-                    filemtime($file) < time() - $seconds
+                    filemtime($filePath) < time() - $seconds
                 ) {
-                    unlink($file);
+                    unlink($filePath);
                 }
             }
         }

--- a/src/ProcessManagerBundle/Controller/ProcessController.php
+++ b/src/ProcessManagerBundle/Controller/ProcessController.php
@@ -18,7 +18,6 @@ use CoreShop\Bundle\ResourceBundle\Controller\ResourceController;
 use Pimcore\Db;
 use ProcessManagerBundle\Model\Process;
 use ProcessManagerBundle\Model\ProcessInterface;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -107,14 +106,14 @@ class ProcessController extends ResourceController
         );
     }
 
-    public function clearAction(Request $request, ParameterBagInterface $parameterBag): JsonResponse
+    public function clearAction(Request $request): JsonResponse
     {
         $seconds = (int)$request->get('seconds', 604_800);
         $connection = Db::get();
         $connection->executeStatement('DELETE FROM process_manager_processes  WHERE started < UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL ? SECOND))', [$seconds]);
 
-        $logDirectory = $parameterBag->get('process_manager.log_directory');
-        $keepLogs = $parameterBag->get('process_manager.keep_logs');
+        $logDirectory = \Pimcore::getContainer()->getParameter('process_manager.log_directory');
+        $keepLogs = \Pimcore::getContainer()->getParameter('process_manager.keep_logs');
         if (!$keepLogs && is_dir($logDirectory)) {
             $files = scandir($logDirectory);
             foreach ($files as $file) {

--- a/src/ProcessManagerBundle/Controller/ProcessController.php
+++ b/src/ProcessManagerBundle/Controller/ProcessController.php
@@ -14,15 +14,7 @@
 
 namespace ProcessManagerBundle\Controller;
 
-use CoreShop\Bundle\ResourceBundle\Controller\EventDispatcherInterface;
 use CoreShop\Bundle\ResourceBundle\Controller\ResourceController;
-use CoreShop\Bundle\ResourceBundle\Controller\ResourceFormFactoryInterface;
-use CoreShop\Bundle\ResourceBundle\Controller\ViewHandler;
-use CoreShop\Bundle\ResourceBundle\Form\Helper\ErrorSerializer;
-use CoreShop\Component\Resource\Factory\FactoryInterface;
-use CoreShop\Component\Resource\Metadata\MetadataInterface;
-use CoreShop\Component\Resource\Repository\RepositoryInterface;
-use Doctrine\Persistence\ObjectManager;
 use Pimcore\Db;
 use ProcessManagerBundle\Model\Process;
 use ProcessManagerBundle\Model\ProcessInterface;
@@ -133,7 +125,7 @@ class ProcessController extends ResourceController
         $keepLogs = $this->container->getParameter('process_manager.keep_logs');
 
         /** @var CleanupService $cleanupService */
-        $cleanupService = $this->container->get('process_manager.cleanup_service');
+        $cleanupService = $this->container->get(CleanupService::class);
         $cleanupService->cleanupDbEntries($seconds);
         $cleanupService->cleanupLogFiles($logDirectory, $seconds, $keepLogs);
         return $this->json(['success' => true]);

--- a/src/ProcessManagerBundle/DependencyInjection/Configuration.php
+++ b/src/ProcessManagerBundle/DependencyInjection/Configuration.php
@@ -42,7 +42,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('driver')->defaultValue(CoreShopResourceBundle::DRIVER_PIMCORE)->end()
                 ->scalarNode('log_directory')->defaultValue('%kernel.logs_dir%')->end()
-                ->booleanNode('cleanup_log_directory')->defaultValue(true)->end()
+                ->booleanNode('keep_logs')->defaultValue(false)->end()
             ->end()
         ;
 

--- a/src/ProcessManagerBundle/DependencyInjection/Configuration.php
+++ b/src/ProcessManagerBundle/DependencyInjection/Configuration.php
@@ -42,6 +42,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('driver')->defaultValue(CoreShopResourceBundle::DRIVER_PIMCORE)->end()
                 ->scalarNode('log_directory')->defaultValue('%kernel.logs_dir%')->end()
+                ->booleanNode('cleanup_log_directory')->defaultValue(true)->end()
             ->end()
         ;
 

--- a/src/ProcessManagerBundle/DependencyInjection/Configuration.php
+++ b/src/ProcessManagerBundle/DependencyInjection/Configuration.php
@@ -42,7 +42,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('driver')->defaultValue(CoreShopResourceBundle::DRIVER_PIMCORE)->end()
                 ->scalarNode('log_directory')->defaultValue('%kernel.logs_dir%')->end()
-                ->booleanNode('keep_logs')->defaultValue(false)->end()
+                ->booleanNode('keep_logs')->defaultValue(true)->end()
             ->end()
         ;
 

--- a/src/ProcessManagerBundle/DependencyInjection/Configuration.php
+++ b/src/ProcessManagerBundle/DependencyInjection/Configuration.php
@@ -43,6 +43,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('driver')->defaultValue(CoreShopResourceBundle::DRIVER_PIMCORE)->end()
                 ->scalarNode('log_directory')->defaultValue('%kernel.logs_dir%')->end()
                 ->booleanNode('keep_logs')->defaultValue(true)->end()
+                ->integerNode('seconds')->defaultValue(604800)->end()
             ->end()
         ;
 

--- a/src/ProcessManagerBundle/DependencyInjection/ProcessManagerExtension.php
+++ b/src/ProcessManagerBundle/DependencyInjection/ProcessManagerExtension.php
@@ -30,7 +30,7 @@ class ProcessManagerExtension extends AbstractModelExtension
         $this->registerPimcoreResources('process_manager', $config['pimcore_admin'], $container);
 
         $container->setParameter('process_manager.log_directory', $config['log_directory']);
-        $container->setParameter('process_manager.cleanup_log_directory', $config['cleanup_log_directory']);
+        $container->setParameter('process_manager.keep_logs', $config['keep_logs']);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');

--- a/src/ProcessManagerBundle/DependencyInjection/ProcessManagerExtension.php
+++ b/src/ProcessManagerBundle/DependencyInjection/ProcessManagerExtension.php
@@ -31,6 +31,7 @@ class ProcessManagerExtension extends AbstractModelExtension
 
         $container->setParameter('process_manager.log_directory', $config['log_directory']);
         $container->setParameter('process_manager.keep_logs', $config['keep_logs']);
+        $container->setParameter('process_manager.seconds', $config['seconds']);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');

--- a/src/ProcessManagerBundle/DependencyInjection/ProcessManagerExtension.php
+++ b/src/ProcessManagerBundle/DependencyInjection/ProcessManagerExtension.php
@@ -30,6 +30,7 @@ class ProcessManagerExtension extends AbstractModelExtension
         $this->registerPimcoreResources('process_manager', $config['pimcore_admin'], $container);
 
         $container->setParameter('process_manager.log_directory', $config['log_directory']);
+        $container->setParameter('process_manager.cleanup_log_directory', $config['cleanup_log_directory']);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');

--- a/src/ProcessManagerBundle/Logger/DefaultHandlerFactory.php
+++ b/src/ProcessManagerBundle/Logger/DefaultHandlerFactory.php
@@ -20,10 +20,12 @@ use ProcessManagerBundle\Model\ProcessInterface;
 class DefaultHandlerFactory implements HandlerFactoryInterface
 {
     private string $logDirectory;
+    private bool $cleanup_log_directory;
 
-    public function __construct(string $logDirectory)
+    public function __construct(string $logDirectory, bool $cleanup_log_directory)
     {
         $this->logDirectory = $logDirectory;
+        $this->cleanup_log_directory = $cleanup_log_directory;
     }
 
     public function getLogHandler(ProcessInterface $process): StreamHandler
@@ -46,7 +48,7 @@ class DefaultHandlerFactory implements HandlerFactoryInterface
     {
         $path = sprintf('%s/process_manager_%s.log', $this->logDirectory, $process->getId());
 
-        if (file_exists($path)) {
+        if ($this->cleanup_log_directory && file_exists($path)) {
             unlink($path);
         }
     }

--- a/src/ProcessManagerBundle/Logger/DefaultHandlerFactory.php
+++ b/src/ProcessManagerBundle/Logger/DefaultHandlerFactory.php
@@ -20,12 +20,12 @@ use ProcessManagerBundle\Model\ProcessInterface;
 class DefaultHandlerFactory implements HandlerFactoryInterface
 {
     private string $logDirectory;
-    private bool $cleanup_log_directory;
+    private bool $keepLogs;
 
-    public function __construct(string $logDirectory, bool $cleanup_log_directory)
+    public function __construct(string $logDirectory, bool $keepLogs)
     {
         $this->logDirectory = $logDirectory;
-        $this->cleanup_log_directory = $cleanup_log_directory;
+        $this->keepLogs = $keepLogs;
     }
 
     public function getLogHandler(ProcessInterface $process): StreamHandler
@@ -48,7 +48,7 @@ class DefaultHandlerFactory implements HandlerFactoryInterface
     {
         $path = sprintf('%s/process_manager_%s.log', $this->logDirectory, $process->getId());
 
-        if ($this->cleanup_log_directory && file_exists($path)) {
+        if (!$this->keepLogs && file_exists($path)) {
             unlink($path);
         }
     }

--- a/src/ProcessManagerBundle/Maintenance/CleanupTask.php
+++ b/src/ProcessManagerBundle/Maintenance/CleanupTask.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Process Manager.
+ *
+ * LICENSE
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2018 Jakub Płaskonka (jplaskonka@divante.pl)
+ * @license    https://github.com/dpfaffenbauer/ProcessManager/blob/master/gpl-3.0.txt GNU General Public License version 3 (GPLv3)
+ */
+
+namespace ProcessManagerBundle\Maintenance;
+
+use Pimcore\Maintenance\TaskInterface;
+use ProcessManagerBundle\Service\CleanupService;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+class CleanupTask implements TaskInterface
+{
+    private CleanupService $cleanupService;
+    private ParameterBagInterface $parameterBag;
+
+    public function __construct(CleanupService $cleanupService, ParameterBagInterface $parameterBag) {
+        $this->cleanupService = $cleanupService;
+        $this->parameterBag = $parameterBag;
+    }
+    public function execute(): void
+    {
+        $seconds = $this->parameterBag->get('process_manager.seconds');
+        $logDirectory = $this->parameterBag->get('process_manager.log_directory');
+        $keepLogs = $this->parameterBag->get('process_manager.keep_logs');
+        $this->cleanupService->cleanupDbEntries($seconds);
+        $this->cleanupService->cleanupLogFiles($logDirectory, $seconds, $keepLogs);
+    }
+}

--- a/src/ProcessManagerBundle/Maintenance/CleanupTask.php
+++ b/src/ProcessManagerBundle/Maintenance/CleanupTask.php
@@ -16,23 +16,14 @@ namespace ProcessManagerBundle\Maintenance;
 
 use Pimcore\Maintenance\TaskInterface;
 use ProcessManagerBundle\Service\CleanupService;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 class CleanupTask implements TaskInterface
 {
-    private CleanupService $cleanupService;
-    private ParameterBagInterface $parameterBag;
-
-    public function __construct(CleanupService $cleanupService, ParameterBagInterface $parameterBag) {
-        $this->cleanupService = $cleanupService;
-        $this->parameterBag = $parameterBag;
+    public function __construct(private CleanupService $cleanupService, private string $logDirectory, private int $seconds, private bool $keepLogs) {
     }
     public function execute(): void
     {
-        $seconds = $this->parameterBag->get('process_manager.seconds');
-        $logDirectory = $this->parameterBag->get('process_manager.log_directory');
-        $keepLogs = $this->parameterBag->get('process_manager.keep_logs');
-        $this->cleanupService->cleanupDbEntries($seconds);
-        $this->cleanupService->cleanupLogFiles($logDirectory, $seconds, $keepLogs);
+        $this->cleanupService->cleanupDbEntries($this->seconds);
+        $this->cleanupService->cleanupLogFiles($this->logDirectory, $this->seconds, $this->keepLogs);
     }
 }

--- a/src/ProcessManagerBundle/Resources/config/services.yml
+++ b/src/ProcessManagerBundle/Resources/config/services.yml
@@ -70,7 +70,7 @@ services:
     ProcessManagerBundle\Logger\DefaultHandlerFactory:
         arguments:
             - '%process_manager.log_directory%'
-            - '%process_manager.cleanup_log_directory%'
+            - '%process_manager.keep_logs%'
 
     ProcessManagerBundle\Report\DefaultReport: ~
 

--- a/src/ProcessManagerBundle/Resources/config/services.yml
+++ b/src/ProcessManagerBundle/Resources/config/services.yml
@@ -45,13 +45,20 @@ services:
         tags:
             - { name: kernel.event_listener, event: pimcore.asset.postDelete, method: onArtifactAssetDelete }
 
-    ### Maintenance task
+    ### Maintenance tasks
     ProcessManagerBundle\Maintenance\CronTask:
         arguments:
             - '@process_manager.registry.processes'
             - '@messenger.default_bus'
         tags:
             - { name: pimcore.maintenance.task, type: process_manager.maintenance.cron }
+
+    ProcessManagerBundle\Maintenance\CleanupTask:
+        arguments:
+            - '@process_manager.cleanup_service'
+            - '@parameter_bag'
+        tags:
+            - { name: pimcore.maintenance.task, type: process_manager.maintenance.cleanup }
 
     ProcessManagerBundle\Logger\ProcessLogger:
         arguments:
@@ -97,3 +104,11 @@ services:
             - '@process_manager.registry.processes'
         tags:
             - { name: messenger.message_handler }
+
+    ### Cleanup service
+    ProcessManagerBundle\Service\CleanupService:
+        arguments:
+            - '@parameter_bag'
+
+    # service IDs used by the codebase directly
+    process_manager.cleanup_service: '@ProcessManagerBundle\Service\CleanupService'

--- a/src/ProcessManagerBundle/Resources/config/services.yml
+++ b/src/ProcessManagerBundle/Resources/config/services.yml
@@ -55,8 +55,10 @@ services:
 
     ProcessManagerBundle\Maintenance\CleanupTask:
         arguments:
-            - '@process_manager.cleanup_service'
-            - '@parameter_bag'
+            - '@ProcessManagerBundle\Service\CleanupService'
+            - '%process_manager.log_directory%'
+            - '%process_manager.seconds%'
+            - '%process_manager.keep_logs%'
         tags:
             - { name: pimcore.maintenance.task, type: process_manager.maintenance.cleanup }
 

--- a/src/ProcessManagerBundle/Resources/config/services.yml
+++ b/src/ProcessManagerBundle/Resources/config/services.yml
@@ -111,6 +111,3 @@ services:
     ProcessManagerBundle\Service\CleanupService:
         arguments:
             - '@parameter_bag'
-
-    # service IDs used by the codebase directly
-    process_manager.cleanup_service: '@ProcessManagerBundle\Service\CleanupService'

--- a/src/ProcessManagerBundle/Resources/config/services.yml
+++ b/src/ProcessManagerBundle/Resources/config/services.yml
@@ -1,6 +1,7 @@
 imports:
     - { resource: "services/forms.yml" }
     - { resource: "services/installer.yml" }
+    - { resource: "services/commands.yml" }
 
 services:
     _defaults:
@@ -69,6 +70,7 @@ services:
     ProcessManagerBundle\Logger\DefaultHandlerFactory:
         arguments:
             - '%process_manager.log_directory%'
+            - '%process_manager.cleanup_log_directory%'
 
     ProcessManagerBundle\Report\DefaultReport: ~
 

--- a/src/ProcessManagerBundle/Resources/config/services/commands.yml
+++ b/src/ProcessManagerBundle/Resources/config/services/commands.yml
@@ -1,0 +1,6 @@
+services:
+  ProcessManagerBundle\Command\CleanupProcessDataCommand:
+    arguments:
+      - '%process_manager.log_directory%'
+    tags:
+      - { name: 'console.command', command: 'process-manager:cleanup-process-data' }

--- a/src/ProcessManagerBundle/Resources/config/services/commands.yml
+++ b/src/ProcessManagerBundle/Resources/config/services/commands.yml
@@ -1,6 +1,7 @@
 services:
-  ProcessManagerBundle\Command\CleanupProcessDataCommand:
-    arguments:
-      - '%process_manager.log_directory%'
-    tags:
-      - { name: 'console.command', command: 'process-manager:cleanup-process-data' }
+    ProcessManagerBundle\Command\CleanupProcessDataCommand:
+        arguments:
+            - '@ProcessManagerBundle\Service\CleanupService'
+            - '%process_manager.log_directory%'
+        tags:
+            - { name: 'console.command', command: 'process-manager:cleanup-process-data' }

--- a/src/ProcessManagerBundle/Resources/public/pimcore/js/processes.js
+++ b/src/ProcessManagerBundle/Resources/public/pimcore/js/processes.js
@@ -145,6 +145,7 @@ pimcore.plugin.processmanager.processes = Class.create({
             xtype: 'grid',
             store: store,
             bbar: pimcore.helpers.grid.buildDefaultPagingToolbar(store),
+            plugins: 'gridfilters',
             columns: [
                 {
                     text: t('id'),
@@ -154,12 +155,14 @@ pimcore.plugin.processmanager.processes = Class.create({
                 {
                     text: t('name'),
                     dataIndex: 'name',
-                    width: 300
+                    width: 400,
+                    filter: 'string'
                 },
                 {
                     text: t('processmanager_message'),
                     dataIndex: 'message',
-                    flex : 1
+                    flex : 1,
+                    filter: 'string'
                 },
                 {
                     text: t('processmanager_started'),
@@ -273,6 +276,7 @@ pimcore.plugin.processmanager.processes = Class.create({
                     text : t('processmanager_status'),
                     width: 100,
                     dataIndex: 'status',
+                    filter: 'string',
                     renderer: function (value, metadata, record) {
                         if (record.data.status != '' && record.data.status != null) {
                             return t('processmanager_' + record.data.status);

--- a/src/ProcessManagerBundle/Service/CleanupService.php
+++ b/src/ProcessManagerBundle/Service/CleanupService.php
@@ -20,10 +20,8 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 class CleanupService
 {
-    public ParameterBagInterface $parameterBag;
-    public function __construct(ParameterBagInterface $parameterBag)
+    public function __construct(protected ParameterBagInterface $parameterBag)
     {
-        $this->parameterBag = $parameterBag;
     }
 
     /**

--- a/src/ProcessManagerBundle/Service/CleanupService.php
+++ b/src/ProcessManagerBundle/Service/CleanupService.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Process Manager.
+ *
+ * LICENSE
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2015-2020 Dominik Pfaffenbauer (https://www.pfaffenbauer.at)
+ * @license    https://github.com/dpfaffenbauer/ProcessManager/blob/master/gpl-3.0.txt GNU General Public License version 3 (GPLv3)
+ */
+
+namespace ProcessManagerBundle\Service;
+
+use Doctrine\DBAL\Exception;
+use Pimcore\Db;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+class CleanupService
+{
+    public ParameterBagInterface $parameterBag;
+    public function __construct(ParameterBagInterface $parameterBag)
+    {
+        $this->parameterBag = $parameterBag;
+    }
+
+    /**
+     * Cleanup process db entries from the database
+     *
+     * @param int|null $seconds Only entries older than x seconds will be deleted
+     *                          None or empty value will delete all entries
+     * @throws Exception
+     */
+    public function cleanupDbEntries(?int $seconds): void
+    {
+        // delete all entries if there is no time passed
+        if (empty($seconds)) {
+            $seconds = 0;
+        }
+        $connection = Db::get();
+        $connection->executeStatement('DELETE FROM process_manager_processes  WHERE started < UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL ? SECOND))', [$seconds]);
+    }
+
+    /**
+     * Cleanup all log files
+     *
+     * @param string $logDirectory Path to the log files. If not specified, default path from config will be used
+     * @param int|null $seconds Only entries older than x seconds will be deleted
+     *                          None or empty value will delete all entries
+     * @param bool $keepLogs Whether to keep the log files or not
+     *                       true - Keep the log files
+     *                       false - Cleanup the logiles
+     * @return void
+     */
+    public function cleanupLogFiles(string $logDirectory, ?int $seconds, bool $keepLogs = true): void
+    {
+        if (empty($logDirectory)) {
+            $logDirectory = $this->parameterBag->get('process_manager.log_directory');
+        }
+        // delete all entries if there is no time passed
+        if (empty($seconds)) {
+            $seconds = 0;
+        }
+        if (!$keepLogs && is_dir($logDirectory)) {
+            $files = scandir($logDirectory);
+            foreach ($files as $file) {
+                $filePath = $logDirectory . '/' . $file;
+                if (
+                    file_exists($filePath) &&
+                    str_contains($file, 'process_manager_') &&
+                    filemtime($filePath) < time() - $seconds
+                ) {
+                    unlink($filePath);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #90

Added a command `process-manager:cleanup-process-data` to clean up process db entries and log files.

The following options can be added to the commands:

- `seconds`: Will clean up entries and logfiles older than this number of seconds
- `keeplogs`: If set the logs won't be deleted

Added a new config option `process_manager.keep_logs` to set a global config setting. If config is set to `process_manager.keep_logs=true`, then the logfiles won't be deleted if there is a delete action from the admin UI. Default value is set `false` and the log files won't be deleted. Decision was made to keep the backward compatibility.

Additionally added the grid filter plugin to the `name`, `message` and `status` column in the admin UI. Makes it much easier to follow and filter for certain tasks.
